### PR TITLE
Print numbering

### DIFF
--- a/index.css
+++ b/index.css
@@ -321,7 +321,7 @@ nav>ul { padding: 0.5em 1em }
   .entry-num {
     display: block; /* none -> block */
     float: right;
-    margin-right: -5em;
+    margin-right: -11em;
     width: 18pt; /* 3*(5+1) = 18 */
     text-align: right;
     letter-spacing: 0;
@@ -329,7 +329,7 @@ nav>ul { padding: 0.5em 1em }
 
   .entry-num:first-child {
     float: left;
-    margin-left: -5em;
+    margin-left: -11em;
     text-align: left;
   }
 
@@ -383,4 +383,32 @@ nav>ul { padding: 0.5em 1em }
     padding: 0;
   }
   #wxdyh_qrcode>img { border: 0.2pt solid #44b549; }
+}
+
+/*
+when the paper width is less than or equal to the
+width of an A5 paper, use the following style
+to accommodate the shrink in available space.
+
+Note: Unlike Firefox and Edge, Chrome doesn't respect the
+set pico point size. Instead, it seems to have 483px for
+A5's width, and 717px for A4's width.
+*/
+@media print and (max-width: 420pt) {
+  .entries-container {
+    max-width: 29.7em; /* 33 - 1.1*4 = 29.7 */
+  }
+  #the-title { font-size: 20pt; }
+  .编 { font-size: 16pt; }
+  .章 { font-size: 12pt; }
+  .节 {
+    font-size: 12pt;
+    font-weight: normal;
+  }
+  .entry-num {
+    margin-right: -3em;
+  }
+  .entry-num:first-child {
+    margin-left: -3em;
+  }
 }

--- a/index.css
+++ b/index.css
@@ -319,16 +319,17 @@ nav>ul { padding: 0.5em 1em }
   }
 
   .entry-num {
-    display: block;
-    position: absolute;
-    right: 0;
+    display: block; /* none -> block */
+    float: right;
+    margin-right: -5em;
     width: 18pt; /* 3*(5+1) = 18 */
     text-align: right;
     letter-spacing: 0;
   }
 
   .entry-num:first-child {
-    left: 0;
+    float: left;
+    margin-left: -5em;
     text-align: left;
   }
 

--- a/main.js
+++ b/main.js
@@ -524,29 +524,30 @@ var qrcodeGenerator = (function () {
   };
 })();
 
-if ("onbeforeprint" in window && "onafterprint" in window) {
-  window.onbeforeprint = function () {
-    var es = document.getElementsByClassName("entry");
-    printNum.addTo(es);
-    qrcodeGenerator.show();
-  };
-  window.onafterprint = function () {
-    var es = document.getElementsByClassName("entry");
-    printNum.rmFrom(es);
-    qrcodeGenerator.clear();
-  };
-} else if ("matchMedia" in window) {
-  window.matchMedia("print").addListener(function (pe) {
-    var es = document.getElementsByClassName("entry");
-
-    if (pe.matches) {
+var printHandler = (function () {
+  var es;
+  return {
+    before: function () {
+      es = document.getElementsByClassName("entry");
+      if (es.length === 0) return;
       printNum.addTo(es);
       qrcodeGenerator.show();
-    }
-    else {
+    },
+    after: function () {
+      if (!es) return;
       printNum.rmFrom(es);
       qrcodeGenerator.clear();
     }
+  };
+})();
+
+if ("onbeforeprint" in window && "onafterprint" in window) {
+  window.onbeforeprint = printHandler.before;
+  window.onafterprint = printHandler.after;
+} else if ("matchMedia" in window) {
+  window.matchMedia("print").addListener(function (pe) {
+    if (pe.matches) printHandler.before();
+    else printHandler.after();
   });
 }
 


### PR DESCRIPTION
Replace absolution positioning with floating, thus making entry numbers being printed correctly in Firefox.

However, the new implementation makes the print layout in Chrome less than satisfactory, due to the unusual paper size (A4, A5 for example) being set to trigger our re-layout functions.

Now, Firefox becomes the best choice for printing, Edge the second, Chrome the third.