### PR TITLE
Print numbering: float positioning -> table layout

### DIFF
--- a/index.css
+++ b/index.css
@@ -59,7 +59,6 @@ h1, h2, h3, h4 {
   margin: 0 auto;
   padding: 0 0.5em;
   background-color: inherit;
-  max-width: 32em;
 }
 
 #back-button, #share-button, #cancel-overlay, #do-copy {
@@ -123,6 +122,7 @@ h1, h2, h3, h4 {
   margin: 1em 0;
   border-left: 1px solid red;
   line-height: 2;
+  max-width: 31.4em; /* 1.05*28 + 2 = 31.4 */
 }
 
 .entry a {
@@ -253,8 +253,6 @@ nav>ul { padding: 0.5em 1em }
 }
 
 @media print {
-  .entries-container { max-width: 33em; }
-
   .li-head { page-break-inside: avoid;}
 
   #toc, #the-preface { page-break-after: always; }
@@ -270,7 +268,7 @@ nav>ul { padding: 0.5em 1em }
   body {
     font-size: 10pt;
     font-family: "AR PL UMing CN", SimSun, "宋体", serif;
-    letter-spacing: 0.5pt;
+    letter-spacing: 0.5pt; /* 10 * 0.05 = 0.5 */
   }
 
   p { text-indent: 2.2em; }
@@ -306,6 +304,7 @@ nav>ul { padding: 0.5em 1em }
   }
 
   .entry {
+    margin: 0 auto;
     border-left: 0.2pt solid red;
   }
 
@@ -318,20 +317,18 @@ nav>ul { padding: 0.5em 1em }
     border-bottom: 0.2pt solid blue;
   }
 
+  .entry-wrapper { width: 100%; }
+  .entry-wrapper td { vertical-align: top; }
+  .entry-wrapper td:first-child { text-align: left; }
+  .entry-wrapper td:nth-child(3) { text-align: right; }
+
   .entry-num {
     display: block; /* none -> block */
-    float: right;
-    margin-right: -11em;
-    width: 18pt; /* 3*(5+1) = 18 */
-    text-align: right;
+    min-width: 18pt; /* 3*(5+1) = 18 */
     letter-spacing: 0;
   }
 
-  .entry-num:first-child {
-    float: left;
-    margin-left: -11em;
-    text-align: left;
-  }
+  .entry>.entry-num { display: none; }
 
   .li-head>a {
     border-bottom: none;
@@ -358,9 +355,10 @@ nav>ul { padding: 0.5em 1em }
     min-width: 0;
   }
 
-  /* sorry for the magic/fragile number 4, wish
-     there is a selector for the nth class :( */
-  .款:nth-child(4)>p:first-child {
+  /* 3 is for the first .款 after .entry-num and .title.
+     Sorry for the magic/fragile number 4,
+     wish there is a selector for the nth class :( */
+  .款:nth-child(3)>p:first-child {
     text-indent: 0;
   }
 
@@ -383,32 +381,4 @@ nav>ul { padding: 0.5em 1em }
     padding: 0;
   }
   #wxdyh_qrcode>img { border: 0.2pt solid #44b549; }
-}
-
-/*
-when the paper width is less than or equal to the
-width of an A5 paper, use the following style
-to accommodate the shrink in available space.
-
-Note: Unlike Firefox and Edge, Chrome doesn't respect the
-set pico point size. Instead, it seems to have 483px for
-A5's width, and 717px for A4's width.
-*/
-@media print and (max-width: 420pt) {
-  .entries-container {
-    max-width: 29.7em; /* 33 - 1.1*4 = 29.7 */
-  }
-  #the-title { font-size: 20pt; }
-  .编 { font-size: 16pt; }
-  .章 { font-size: 12pt; }
-  .节 {
-    font-size: 12pt;
-    font-weight: normal;
-  }
-  .entry-num {
-    margin-right: -3em;
-  }
-  .entry-num:first-child {
-    margin-left: -3em;
-  }
 }

--- a/index.css
+++ b/index.css
@@ -59,6 +59,7 @@ h1, h2, h3, h4 {
   margin: 0 auto;
   padding: 0 0.5em;
   background-color: inherit;
+  max-width: 503.4px; /* 16*(1.05*28 + 2) + 1(border-left) */
 }
 
 #back-button, #share-button, #cancel-overlay, #do-copy {
@@ -122,7 +123,6 @@ h1, h2, h3, h4 {
   margin: 1em 0;
   border-left: 1px solid red;
   line-height: 2;
-  max-width: 31.4em; /* 1.05*28 + 2 = 31.4 */
 }
 
 .entry a {
@@ -253,6 +253,12 @@ nav>ul { padding: 0.5em 1em }
 }
 
 @media print {
+  .entries-container { max-width: none; }
+  .entries-container>div, .entries-container>p {
+    max-width: 31.4em;
+    margin-left: auto;
+    margin-right: auto;
+  }
   .li-head { page-break-inside: avoid;}
 
   #toc, #the-preface { page-break-after: always; }
@@ -306,6 +312,7 @@ nav>ul { padding: 0.5em 1em }
   .entry {
     margin: 0 auto;
     border-left: 0.2pt solid red;
+    max-width: 31.4em;
   }
 
   .entry a {

--- a/index.css
+++ b/index.css
@@ -319,12 +319,19 @@ nav>ul { padding: 0.5em 1em }
 
   .entry-wrapper { width: 100%; }
   .entry-wrapper td { vertical-align: top; }
-  .entry-wrapper td:first-child { text-align: left; }
-  .entry-wrapper td:nth-child(3) { text-align: right; }
+  .entry-wrapper td:first-child {
+    text-align: left;
+    width: 18pt;
+  }
+  .entry-wrapper td:nth-child(3) {
+    text-align: right;
+    width: 18pt;
+  }
 
   .entry-num {
     display: block; /* none -> block */
-    min-width: 18pt; /* 3*(5+1) = 18 */
+    width: 100%;
+    line-height: 2em;
     letter-spacing: 0;
   }
 

--- a/main.js
+++ b/main.js
@@ -455,27 +455,54 @@ tapOn(window, tapHandler, true);
 /*
  The following code transforms page for print media.
  Require browsers' support for window.matchMedia("print").
-*/
+ */
+
+function tabulateATriple(a, b, c) {
+  var table = document.createElement("TABLE"),
+      tr = document.createElement("TR"),
+      appendCell = function (row, x) {
+        var td = document.createElement("TD");
+        td.appendChild(x);
+        row.appendChild(td);
+      };
+
+  appendCell(tr, a);
+  appendCell(tr, b);
+  appendCell(tr, c);
+  table.appendChild(tr);
+  return table;
+}
+
 var printNum = (function () {
-  var firstENum = function (entry) {
-    return entry.querySelector(".entry-num");
+  var parent = function (e) {
+    return e.parentNode;
   };
-  var addAnother = function (p, x) {
-    if (x) p.insertBefore(x.cloneNode(true), x);
+  var wrap = function (e, p) {
+    var wrapper,
+        ec = e.cloneNode(true),
+        en = e.querySelector(".entry-num"),
+        enl = en.cloneNode(true),
+        enr = en.cloneNode(true);
+
+    wrapper = tabulateATriple(enl, ec, enr);
+    wrapper.className = "entry-wrapper";
+    p.replaceChild(wrapper, e);
   };
-  var remove = function (p, x) {
-    if (x) p.removeChild(x);
+  var unwrap = function (wrapper, p) {
+    var e = wrapper.querySelector(".entry");
+
+    p.replaceChild(e, wrapper);
   };
 
   return {
     addTo: function (es) {
       // add a copy for each entry-num element so that
       // the entry-num can be print on both hands of a page
-      iter(es, addAnother, firstENum);
+      iter(es, wrap, parent);
     },
     rmFrom: function (es) {
       // remove the inserted entry-num elements
-      iter(es, remove, firstENum);
+      iter(es, unwrap, parent);
     }
   };
 })();
@@ -525,17 +552,16 @@ var qrcodeGenerator = (function () {
 })();
 
 var printHandler = (function () {
-  var es;
   return {
     before: function () {
-      es = document.getElementsByClassName("entry");
+      var es = document.querySelectorAll("section[class=entry]");
       if (es.length === 0) return;
       printNum.addTo(es);
       qrcodeGenerator.show();
     },
     after: function () {
-      if (!es) return;
-      printNum.rmFrom(es);
+      var ews = document.querySelectorAll(".entry-wrapper");
+      printNum.rmFrom(ews);
       qrcodeGenerator.clear();
     }
   };


### PR DESCRIPTION
Table layout solution:

Pros:
- dynamically adjusts to different paper sizes (vs float)
- allows page-break-inside (vs flexbox)

Cons:
- requires complex DOM updates throughout the entire document before&after print, resulting in a little slower print-preview pop-up, and incomplete document at the end in Chrome (bug?) (vs float)
- may allow numbering appear at the bottom of the current page, while the content itself appear at the top of the next page (vs float, vs flexbox)